### PR TITLE
Refactor apiGroup references in RBAC roles and dataset config

### DIFF
--- a/config/crd/patches/cainjection_in_datasets.yaml
+++ b/config/crd/patches/cainjection_in_datasets.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
-  name: datasets.kokabie.li.kokabie.li
+  name: datasets.kokabie.li

--- a/config/crd/patches/webhook_in_datasets.yaml
+++ b/config/crd/patches/webhook_in_datasets.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: datasets.kokabie.li.kokabie.li
+  name: datasets.kokabie.li
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/dataset_editor_role.yaml
+++ b/config/rbac/dataset_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: dataset-editor-role
 rules:
 - apiGroups:
-  - kokabie.li.kokabie.li
+  - kokabie.li
   resources:
   - datasets
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - kokabie.li.kokabie.li
+  - kokabie.li
   resources:
   - datasets/status
   verbs:

--- a/config/rbac/dataset_viewer_role.yaml
+++ b/config/rbac/dataset_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: dataset-viewer-role
 rules:
 - apiGroups:
-  - kokabie.li.kokabie.li
+  - kokabie.li
   resources:
   - datasets
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - kokabie.li.kokabie.li
+  - kokabie.li
   resources:
   - datasets/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -95,7 +95,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - kokabie.li.kokabie.li
+  - kokabie.li
   resources:
   - datasets
   verbs:
@@ -107,13 +107,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - kokabie.li.kokabie.li
+  - kokabie.li
   resources:
   - datasets/finalizers
   verbs:
   - update
 - apiGroups:
-  - kokabie.li.kokabie.li
+  - kokabie.li
   resources:
   - datasets/status
   verbs:

--- a/config/samples/kokabie.li_v1alpha1_dataset.yaml
+++ b/config/samples/kokabie.li_v1alpha1_dataset.yaml
@@ -1,4 +1,4 @@
-apiVersion: kokabie.li.kokabie.li/v1alpha1
+apiVersion: kokabie.li/v1alpha1
 kind: DataSet
 metadata:
   labels:

--- a/internal/controller/dataset_controller.go
+++ b/internal/controller/dataset_controller.go
@@ -49,9 +49,9 @@ type DataSetReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=kokabie.li.kokabie.li,resources=datasets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=kokabie.li.kokabie.li,resources=datasets/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=kokabie.li.kokabie.li,resources=datasets/finalizers,verbs=update
+//+kubebuilder:rbac:groups=kokabie.li,resources=datasets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=kokabie.li,resources=datasets/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=kokabie.li,resources=datasets/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Addressed incorrect apiGroup references in various configurations and RBAC roles related to the 'datasets' custom resource. Previously, the apiGroup was specified as 'kokabie.li.kokabie.li' which wasn't correct. This change updates these references to the correct 'kokabie.li' across all affected files.